### PR TITLE
Fix: Corrige error de deserializacion de ErrorContpaqiResponse

### DIFF
--- a/src/Api.Core.Domain/Api.Core.Domain.csproj
+++ b/src/Api.Core.Domain/Api.Core.Domain.csproj
@@ -16,7 +16,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="ARSoftware.Contpaqi.Api.Common" Version="1.0.0" />
+		<PackageReference Include="ARSoftware.Contpaqi.Api.Common" Version="1.0.1" />
 		<PackageReference Include="MediatR" Version="12.0.1" />
 	</ItemGroup>
 


### PR DESCRIPTION
Este PR corrige el error donde la API marcaba error al tratar de deserializar un ErrorContpaqiResponse lo que ocasionaba que tronara el sincronizador.